### PR TITLE
Update distro to focal in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 
-dist: bionic
+dist: focal
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ jobs:
         - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version
 
  notifications:
-  email: false
+  email: false 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - docker buildx create --use --name mybuilder
       script:
         - docker login -u ajv21 -p Jun21@2021
-        - travis_wait 20 docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . 
+        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . >> /dev/null 2>&1
         - docker buildx rm mybuilder
       after_success:
         - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,34 @@
 ---
 
-dist: focal
+dist: bionic
 
 services:
   - docker
 
 stages:
+  - Static test
   - Build test
 
 jobs:
   include:
+    - stage: Static test
+      env:
+        - Test: hadolint
+      language: minimal
+      script:
+        - docker run --rm -i -v $PWD/.hadolint.yml:/.hadolint.yml hadolint/hadolint < Dockerfile
+
+    - stage: Static test
+      env:
+        - Test: dockerfile_lint
+      language: node_js
+      node_js:
+        - "12"
+      script:
+        - npx --cache .npx dockerfile_lint
+      cache:
+        directories:
+          - .npx
 
     - stage: Build test
       language: minimal
@@ -17,18 +36,7 @@ jobs:
         - LATEST_AZCOPY="$(curl -sLo- https://api.github.com/repos/Azure/azure-storage-azcopy/releases | jq -r '.[0].tag_name' | sed 's/^v//g')"
         - test -n "$LATEST_AZCOPY"
         - export LATEST_AZCOPY
-        - mkdir -p ~/.docker/cli-plugins
-        - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
-        - chmod a+x ~/.docker/cli-plugins/docker-buildx
-        - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
-        - docker --version
-        - docker buildx create --use --name mybuilder
       script:
-        - docker login -u ajv21 -p Jun21@2021
-        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . >> /temp/log.txt 2>&1
-        - docker buildx rm mybuilder
+        - docker build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t docker-azcopy:$TRAVIS_COMMIT .
       after_success:
-        - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version
-
- notifications:
-  email: false  
+        - docker run --rm docker-azcopy:$TRAVIS_COMMIT azcopy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,10 @@ jobs:
         - docker buildx create --use --name mybuilder
       script:
         - docker login -u ajv21 -p Jun21@2021
-        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . >> /dev/null 2>&1
+        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . >> /temp/log.txt 2>&1
         - docker buildx rm mybuilder
       after_success:
         - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version
+
+ notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,29 +6,10 @@ services:
   - docker
 
 stages:
-  - Static test
   - Build test
 
 jobs:
   include:
-    - stage: Static test
-      env:
-        - Test: hadolint
-      language: minimal
-      script:
-        - docker run --rm -i -v $PWD/.hadolint.yml:/.hadolint.yml hadolint/hadolint < Dockerfile
-
-    - stage: Static test
-      env:
-        - Test: dockerfile_lint
-      language: node_js
-      node_js:
-        - "12"
-      script:
-        - npx --cache .npx dockerfile_lint
-      cache:
-        directories:
-          - .npx
 
     - stage: Build test
       language: minimal
@@ -40,6 +21,7 @@ jobs:
         - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
         - chmod a+x ~/.docker/cli-plugins/docker-buildx
         - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+        - docker --version
         - docker buildx create --use --name mybuilder
       script:
         - docker login -u ajv21 -p Jun21@2021

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ jobs:
         - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version
 
  notifications:
-  email: false 
+  email: false  

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,14 @@ jobs:
         - LATEST_AZCOPY="$(curl -sLo- https://api.github.com/repos/Azure/azure-storage-azcopy/releases | jq -r '.[0].tag_name' | sed 's/^v//g')"
         - test -n "$LATEST_AZCOPY"
         - export LATEST_AZCOPY
+        - mkdir -p ~/.docker/cli-plugins
+        - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+        - chmod a+x ~/.docker/cli-plugins/docker-buildx
+        - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+        - docker buildx create --use --name mybuilder
       script:
-        - docker build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t docker-azcopy:$TRAVIS_COMMIT .
+        - docker login -u ajv21 -p Jun21@2021
+        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push .
+        - docker buildx rm mybuilder
       after_success:
-        - docker run --rm docker-azcopy:$TRAVIS_COMMIT azcopy --version
+        - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - docker buildx create --use --name mybuilder
       script:
         - docker login -u ajv21 -p Jun21@2021
-        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . > /dev/null 
+        - travis_wait 20 docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . 
         - docker buildx rm mybuilder
       after_success:
         - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - docker buildx create --use --name mybuilder
       script:
         - docker login -u ajv21 -p Jun21@2021
-        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push .
+        - docker buildx build --build-arg AZCOPY_VERSION="$LATEST_AZCOPY" -t ajv21/docker-azcopy:$TRAVIS_COMMIT --platform linux/amd64,linux/arm64 --push . > /dev/null 
         - docker buildx rm mybuilder
       after_success:
         - docker run --rm ajv21/docker-azcopy:$TRAVIS_COMMIT azcopy --version


### PR DESCRIPTION
The following file has been created and modified:
Updated the ubuntu distribution to focal from bionic in .travis.yml to support docker utility called docker buildx which push the docker image for arm64 and amd64 platforms.

Signed-off-by: odidev odidev@puresoftware.com